### PR TITLE
Fixed rtdet custom training

### DIFF
--- a/ultralytics/models/utils/ops.py
+++ b/ultralytics/models/utils/ops.py
@@ -104,6 +104,9 @@ class HungarianMatcher(nn.Module):
             C += self._cost_mask(bs, gt_groups, masks, gt_mask)
 
         C = C.view(bs, nq, -1).cpu()
+        # Resolving [ValueError: matrix contains invalid numeric entries], while training on a custom dataset
+        # Set invalid values (NaNs and infinities) to 0 
+        C[C.isnan() | C.isinf()] = 0
         indices = [linear_sum_assignment(c[i]) for i, c in enumerate(C.split(gt_groups, -1))]
         gt_groups = torch.as_tensor([0, *gt_groups[:-1]]).cumsum_(0)
         # (idx for queries, idx for gt)


### PR DESCRIPTION
Remediate "ValueError: matrix contains invalid numeric entries" while training RT-DETR on a custom dataset.